### PR TITLE
DE-107749 Rector action: Use composer script instead of running Rector directly from vendor

### DIFF
--- a/.github/workflows/php-rector.yml
+++ b/.github/workflows/php-rector.yml
@@ -83,9 +83,8 @@ jobs:
             echo "phpstan.neon.example does not exist, skipping copy."
           fi
 
-      # Only --dry-run will fail when changes are detected
       - name: Rector
-        run: vendor/bin/rector process --dry-run
+        run: composer check-rector
 
       # Explicitly save rector cache
       - name: Cache rector save


### PR DESCRIPTION
This will allow projects to supply their own command for running Rector. Every project that uses this action at the moment has the `check-rector` composer script present.